### PR TITLE
use native .length rather than the .size() wrapper

### DIFF
--- a/client/line.coffee
+++ b/client/line.coffee
@@ -29,7 +29,7 @@ window.plugins.line =
         </style>
       '''
       candidates = $(".item:lt(#{$('.item').index(div)})")
-      if (who = candidates.filter ".sequence-source").size()
+      if (who = candidates.filter ".sequence-source").length
         choice = who[who.length-1]
         data = ({x,y:+y} for y,x in choice.getSequenceData())
         x = d3.scale.linear().domain(extent data, (p)->p.x).range([ 0, w ])


### PR DESCRIPTION
Have had this change sitting in my repo for a few months. I forget the exact reason behind the changes, other than it cropped up while working on something else with Ward.